### PR TITLE
Add deps badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Hex.pm](https://img.shields.io/hexpm/v/ex_victor_ops.svg)](https://hex.pm/packages/ex_victor_ops)
 [![Build Status](https://travis-ci.org/cagedata/ex_victor_ops.svg?branch=master)](https://travis-ci.org/cagedata/ex_victor_ops)
+[![Deps Status](https://beta.hexfaktor.org/badge/all/github/cagedata/ex_victor_ops.svg)](https://beta.hexfaktor.org/github/cagedata/ex_victor_ops)
 [![Doc Status](https://inch-ci.org/github/cagedata/ex_victor_ops.svg?branch=master)](https://inch-ci.org/github/cagedata/ex_victor_ops)
 [![Coverage Status](https://coveralls.io/repos/github/cagedata/ex_victor_ops/badge.svg?branch=)](https://coveralls.io/github/cagedata/ex_victor_ops?branch=)
 


### PR DESCRIPTION
Hi there,

I'm the maintainer of [Inch CI](https://inch-ci.org/) and this PR pitches my latest project for the Elixir community.

Here comes the pitch:

[![Deps Status](https://beta.hexfaktor.org/badge/all/github/cagedata/ex_victor_ops.svg)](https://beta.hexfaktor.org/github/cagedata/ex_victor_ops) [![Inline docs](http://inch-ci.org/github/cagedata/ex_victor_ops.svg?branch=master)](http://inch-ci.org/github/cagedata/ex_victor_ops)

You already know the Inch badge on the right: It shows you an analysis for your Elixir project's docs. The new badge does the same thing for your dependencies.

Behind the badge works a CI service written in Elixir which can notify you whenever important updates for your Hex packages are released.

This is still in its infancy, and I want to basically invite you to join the beta to test-drive this. I really believe that we can create a great service for the community with this. That said, don't feel any obligation to accept the PR. You can't hurt my feelings by voicing your honest opinion about this idea!
